### PR TITLE
fix(messaging): only check once after 8pm

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -37,4 +37,4 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v1
     - name: Deploy
-      run: kubectl apply -f deployments/nozerodays.yaml
+      run: kubectl rollout restart deployments/nozerodays

--- a/bot/bot.go
+++ b/bot/bot.go
@@ -95,8 +95,12 @@ func (c *Config) Start() {
 			time.Sleep(duration)
 		} else {
 			// send a slack reminder
+			text := "hey! you haven't made a commit today yet. remember, you want to code!"
+			if currentTime.Hour() > 22 {
+				text += " last chance today!!"
+			}
 			msg := slackMsg{
-				Text: "hey! you haven't made a commit today yet. i'll check again in an hour. remember, you want to code!",
+				Text: text,
 			}
 			err = c.sendSlackMsg(msg)
 			if err != nil {
@@ -104,8 +108,8 @@ func (c *Config) Start() {
 			}
 
 			// then sleep for an hour and check again
-			c.logger.Info().Msg("sleeping for an hour to check again")
-			time.Sleep(time.Hour)
+			c.logger.Info().Msg("sleeping for 3 hours to check again")
+			time.Sleep(time.Hour * 3)
 		}
 	}
 }

--- a/deployments/nozerodays.yaml
+++ b/deployments/nozerodays.yaml
@@ -17,6 +17,7 @@ spec:
       containers:
       - name: nozerodays
         image: docker.pkg.github.com/goodbuns/nozerodays/nozerodays:latest
+        imagePullPolicy: Always
         args: ["--username=$(GITHUB_USERNAME)", "--accessToken=$(GITHUB_ACCESS_TOKEN)", "--organizations=$(ORGANIZATIONS)", "--webhook=$(WEBHOOK_URL)", "--location=$(LOCATION)"]
         env:
         - name: LOCATION


### PR DESCRIPTION
### what & why
- fix to only check commits one more time after 8pm, at 11pm (to avoid spamming the engineering channel)
- restarts the deployment because it won't be applied due to the latest tag (should fix that later) ref: https://github.com/kubernetes/kubernetes/issues/27081